### PR TITLE
Refactor HKConnection to use LEDStatus instead of direct low-level RGB

### DIFF
--- a/src/WindowsShutterService.cpp
+++ b/src/WindowsShutterService.cpp
@@ -23,6 +23,7 @@
 #define COVER_OPEN_TO_CLOSE_TRANSMIT_REPEATS 1400 //100 repeat tooked 4500ms
 #define TILT_OPEN_TO_CLOSE_TRANSMIT_REPEATS 40 //100 repeat tooked 4500ms
 
+LEDStatus RGB_STATUS_BLUE(RGB_COLOR_BLUE, LED_PATTERN_SOLID, LED_SPEED_NORMAL, LED_PRIORITY_IMPORTANT);
 
 void WindowsShutterService::setState(int newState) {
     if(state != newState) {
@@ -60,20 +61,18 @@ bool WindowsShutterService::handle() {
     rcSwitch->setRepeatTransmit(transmit_repeats);
     switch (state) {
         case 0:
-            RGB.control(true);
-            RGB.color(0, 0, 255);
+            RGB_STATUS_BLUE.setActive(true);
             rcSwitch->send(downCode, 24);
             hkLog.info("Sending downCode: %d,repeats: %d, took: %d ms\n", downCode,transmit_repeats, millis() - start);
-            RGB.control(false);
+            RGB_STATUS_BLUE.setActive(false);
             newPosition -= diff;
             result = true;
             break;
         case 1:
-            RGB.control(true);
-            RGB.color(0, 0, 255);
+            RGB_STATUS_BLUE.setActive(true);
             rcSwitch->send(upCode, 24);
             hkLog.info("Sending upCode: %d,repeats: %d, took: %d ms\n", upCode,transmit_repeats,millis() - start);
-            RGB.control(false);
+            RGB_STATUS_BLUE.setActive(false);
             newPosition += diff;
             result = true;
             break;

--- a/src/homekit/HKConnection.cpp
+++ b/src/homekit/HKConnection.cpp
@@ -7,6 +7,8 @@ uint8_t SHARED_REQUEST_BUFFER[SHARED_REQUEST_BUFFER_LEN] = {0};
 uint8_t SHARED_RESPONSE_BUFFER[SHARED_RESPONSE_BUFFER_LEN] = {0};
 uint8_t SHARED_TEMP_CRYPTO_BUFFER[SHARED_TEMP_CRYPTO_BUFFER_LEN] = {0};
 
+LEDStatus RGB_STATUS_YELLOW(RGB_COLOR_YELLOW, LED_PATTERN_FADE, LED_PRIORITY_IMPORTANT);
+
 void generateAccessoryKey(ed25519_key *key)
 {
     int r = wc_ed25519_init(key);
@@ -204,8 +206,7 @@ bool HKConnection::handleConnection(bool maxConnectionsVictim)
     if (len > 0)
     {
         lastKeepAliveMs = millis();
-        RGB.control(true);
-        RGB.color(255, 255, 0);
+        RGB_STATUS_YELLOW.setActive(true);
         hkLog.info("Request Message read length: %d ", len);
         HKNetworkMessage msg((const char *)SHARED_REQUEST_BUFFER);
         if (!strcmp(msg.directory, "pair-setup"))
@@ -247,7 +248,7 @@ bool HKConnection::handleConnection(bool maxConnectionsVictim)
           Particle.publish("homekit/accessory", clientID(), PUBLIC);
           handleAccessoryRequest((const char *)SHARED_REQUEST_BUFFER, len);
 
-          RGB.control(false);
+          RGB_STATUS_YELLOW.setActive(false);
           result = true;
         }
     }


### PR DESCRIPTION
This makes the RGB LED flash yellow when handling connections as it did before, but no longer takes direct control of the RGB LED.

* You can now disable the RGB LED in user code (e.g., in your `setup()` function)
* `PhotonSystemLEDLightBulbAccessory` will no longer lose control of LED after the Homekit connection.
* Long-running connections (such as pairing) now show a "breathe" pattern on the RGB LED.