### PR TITLE
Change Particle.publish calls to use private publishing

### DIFF
--- a/examples/BME280TemperatureHumiditySensor/BME280TemperatureHumiditySensorAccessory.cpp
+++ b/examples/BME280TemperatureHumiditySensor/BME280TemperatureHumiditySensorAccessory.cpp
@@ -54,8 +54,8 @@ bool BME280TemperatureHumiditySensorAccessory::handle() {
       if(currentTemperatureChar) currentTemperatureChar->notify(NULL);
       if(currentHumidityChar) currentHumidityChar->notify(NULL);
 
-      Particle.publish("bme280/temperature", String(lastValueTemperature), PUBLIC);
-      Particle.publish("bme280/humidity", String(lastValueHumidity), PUBLIC);
+      Particle.publish("bme280/temperature", String(lastValueTemperature), PRIVATE);
+      Particle.publish("bme280/humidity", String(lastValueHumidity), PRIVATE);
 
       result = true;
   }

--- a/examples/adaptica_door_opener/SerialModemSwitchService.cpp
+++ b/examples/adaptica_door_opener/SerialModemSwitchService.cpp
@@ -17,7 +17,7 @@ std::string SerialModemSwitchService::getPower (HKConnection *sender){
 
 void SerialModemSwitchService::setPower (bool oldValue, bool newValue, HKConnection *sender){
     on = newValue;
-    Particle.publish("serialmodem/power", String(newValue), PUBLIC);
+    Particle.publish("serialmodem/power", String(newValue), PRIVATE);
     if(on) {
         needsSendAT = true;
         
@@ -27,10 +27,10 @@ void SerialModemSwitchService::setPower (bool oldValue, bool newValue, HKConnect
 bool SerialModemSwitchService::handle() {
     if(needsSendAT) {
         needsSendAT = false;
-        Particle.publish("serialmodem/sendcommand", String(openATCommand), PUBLIC);
+        Particle.publish("serialmodem/sendcommand", String(openATCommand), PRIVATE);
         Serial1.write(openATCommand);
         delay(12000);
-        Particle.publish("serialmodem/sendcommand", String("ATH\r"), PUBLIC);
+        Particle.publish("serialmodem/sendcommand", String("ATH\r"), PRIVATE);
         Serial1.write("ATH\r");
         closeTimeout = millis() + 4000;
     }

--- a/examples/homestation/RFRelaySwitchService.cpp
+++ b/examples/homestation/RFRelaySwitchService.cpp
@@ -19,7 +19,7 @@ void RFRelaySwitchService::setPower (bool oldValue, bool newValue, HKConnection 
     on = newValue;
     needsSendCode = true;
 
-    Particle.publish("rfrelay/power", String(newValue), PUBLIC);
+    Particle.publish("rfrelay/power", String(newValue), PRIVATE);
 }
 
 bool RFRelaySwitchService::handle() {
@@ -29,7 +29,7 @@ bool RFRelaySwitchService::handle() {
       rcSwitch->setRepeatTransmit(10);
       rcSwitch->send(code, 24);
 
-      Particle.publish("rfrelay/sendcode", String(code), PUBLIC);
+      Particle.publish("rfrelay/sendcode", String(code), PRIVATE);
 
       return true;
     }

--- a/examples/roomba/RoombaAccessory.cpp
+++ b/examples/roomba/RoombaAccessory.cpp
@@ -37,7 +37,7 @@ std::string RoombaAccessory::getStatusLowBattery (HKConnection *sender){
 
 
 void RoombaAccessory::setPower (bool oldValue, bool newValue, HKConnection *sender){
-    Particle.publish("roomba/power", newValue ? "on" : "off", PUBLIC);
+    Particle.publish("roomba/power", newValue ? "on" : "off", PRIVATE);
     on = newValue;
     if(on) {
       Serial1.write(OI_START_COMM);

--- a/examples/singlenixie/NixieClockAccessory.cpp
+++ b/examples/singlenixie/NixieClockAccessory.cpp
@@ -22,7 +22,7 @@ std::string NixieClockAccessory::getPower (HKConnection *sender){
 }
 
 void NixieClockAccessory::setPower (bool oldValue, bool newValue, HKConnection *sender){
-    Particle.publish("nixie/power", newValue ? "on" : "off", PUBLIC);
+    Particle.publish("nixie/power", newValue ? "on" : "off", PRIVATE);
     on = newValue ? 1 : 0;
 }
 

--- a/src/HKConnection.cpp
+++ b/src/HKConnection.cpp
@@ -212,7 +212,7 @@ bool HKConnection::handleConnection(bool maxConnectionsVictim)
         if (!strcmp(msg.directory, "pair-setup"))
         {
             hkLog.info("Handling Pair Setup...");
-            Particle.publish("homekit/pair-setup", clientID(), PUBLIC);
+            Particle.publish("homekit/pair-setup", clientID(), PRIVATE);
             handlePairSetup((const char *)SHARED_REQUEST_BUFFER);
         }
         else if (!strcmp(msg.directory, "pair-verify"))
@@ -221,14 +221,14 @@ bool HKConnection::handleConnection(bool maxConnectionsVictim)
             if (!maxConnectionsVictim)
             {
               hkLog.info("Handling Pair Verify...");
-              Particle.publish("homekit/pair-verify", clientID(), PUBLIC);
+              Particle.publish("homekit/pair-verify", clientID(), PRIVATE);
               if (handlePairVerify((const char *)SHARED_REQUEST_BUFFER))
               {
                   isEncrypted = true;
                   server->setPaired(true);
               }
             } else {
-                  Particle.publish("homekit/connection-limit", clientID(), PUBLIC);
+                  Particle.publish("homekit/connection-limit", clientID(), PRIVATE);
                   //max connections has been reached.
                   memset(SHARED_RESPONSE_BUFFER, 0, SHARED_RESPONSE_BUFFER_LEN);
                   int len = snprintf((char *)SHARED_RESPONSE_BUFFER, SHARED_RESPONSE_BUFFER_LEN, "HTTP/1.1 503 Service Unavailable\r\n\r\n");
@@ -245,7 +245,7 @@ bool HKConnection::handleConnection(bool maxConnectionsVictim)
         {
           //connection is secured
           hkLog.info("Handling message request: %s", msg.directory);
-          Particle.publish("homekit/accessory", clientID(), PUBLIC);
+          Particle.publish("homekit/accessory", clientID(), PRIVATE);
           handleAccessoryRequest((const char *)SHARED_REQUEST_BUFFER, len);
         }
         

--- a/src/HKServer.cpp
+++ b/src/HKServer.cpp
@@ -96,7 +96,7 @@ bool HKServer::handle() {
         hkLog.info("Client connected.");
         HKConnection *c = new HKConnection(this,newClient);
         clients.insert(clients.end(),c);
-        Particle.publish("homekit/accept", c->clientID(), PUBLIC);
+        Particle.publish("homekit/accept", c->clientID(), PRIVATE);
         result = true;
     }
 
@@ -108,7 +108,7 @@ bool HKServer::handle() {
 
         if(!conn->isConnected()) {
             hkLog.info("Client removed.");
-            Particle.publish("homekit/close", conn->clientID(), PUBLIC);
+            Particle.publish("homekit/close", conn->clientID(), PRIVATE);
             conn->close();
             clients.erase(clients.begin() + i);
             delete conn;


### PR DESCRIPTION
For better security/privacy, Particle recommends publishing with the `PRIVATE` flag.  See [Particle's reference documentation](https://docs.particle.io/reference/device-os/firmware/photon/#particle-publish-).