### PR TITLE
Remove compiler warnings

### DIFF
--- a/src/HAPCompositeAccessory.cpp
+++ b/src/HAPCompositeAccessory.cpp
@@ -15,7 +15,7 @@ void HAPCompositeAccessory::identity(bool oldValue, bool newValue, HKConnection 
 
 bool HAPCompositeAccessory::handle() {
     bool result = false;
-    for(int i = 0; i < descriptors.size(); i++) {
+    for(uint i = 0; i < descriptors.size(); i++) {
         //process only one accessory per "loop" step. So we dont delay Particle connection, Bonjour so much. Never mind it will be process one step later
         result |= descriptors.at(i)->handle();
     }
@@ -29,7 +29,7 @@ void HAPCompositeAccessory::initAccessorySet(){
     addInfoServiceToAccessory(accessory, "Composite accessory", "Vendor name", "Model  name", "1","1.0.0", std::bind(&HAPCompositeAccessory::identity, this, std::placeholders::_1, std::placeholders::_2,std::placeholders::_3));
     accSet->addAccessory(accessory);
 
-    for(int i = 0; i < descriptors.size(); i++) {
+    for(uint i = 0; i < descriptors.size(); i++) {
         descriptors.at(i)->initService(accessory);
     }
 }

--- a/src/HAPHomekitBridgeAccessory.cpp
+++ b/src/HAPHomekitBridgeAccessory.cpp
@@ -10,7 +10,7 @@
 
 bool HAPHomekitBridgeAccessory::handle() {
     bool result = false;
-    for(int i = 0; i < descriptors.size(); i++) {
+    for(uint i = 0; i < descriptors.size(); i++) {
         //process only one accessory per "loop" step. So we dont delay Particle connection, Bonjour so much. Never mind it will be process one step later
         result |= descriptors.at(i)->handle();
     }
@@ -18,7 +18,7 @@ bool HAPHomekitBridgeAccessory::handle() {
 }
 
 void HAPHomekitBridgeAccessory::initAccessorySet(){
-    for(int i = 0; i < descriptors.size(); i++) {
+    for(uint i = 0; i < descriptors.size(); i++) {
         descriptors.at(i)->initAccessorySet();
     }
 }

--- a/src/HKAccessory.cpp
+++ b/src/HKAccessory.cpp
@@ -377,7 +377,7 @@ string dictionaryWrap(string *key, string *value, unsigned short len) {
 }
 
 void characteristics::notify(HKConnection* conn) {
-  for(int i = 0; i<notifiedConnections.size();i++){
+  for(uint i = 0; i<notifiedConnections.size();i++){
       if(conn != notifiedConnections.at(i)) {
           notifiedConnections.at(i)->postCharacteristicsValue(this);
       }

--- a/src/HKAccessory.cpp
+++ b/src/HKAccessory.cpp
@@ -634,7 +634,7 @@ void handleAccessory(const char *request, unsigned int requestLen, char *respons
 
             char *buffer2 = characteristicsBuffer;
             while (strlen(buffer2) && statusCode != 400) {
-                bool reachLast = false; bool updateNotify = false;
+                bool updateNotify = false;
                 char *buffer1;
                 buffer1 = strtok_r(buffer2, "}", &buffer2);
                 if (*buffer2 != 0) buffer2+=2;

--- a/src/HKAccessory.h
+++ b/src/HKAccessory.h
@@ -82,7 +82,7 @@ typedef enum {
     charType_videoRotation      = 0x3C,
     charType_videoValAttr       = 0x3D,
 
-#pragma - The following is only default by the device after iOS 9
+// - The following is only default by the device after iOS 9
 
     charType_firmwareRevision   = 0x52,
     charType_hardwareRevision   = 0x53,
@@ -129,7 +129,7 @@ typedef enum {
     charType_sensorChargingState= 0x8F,
 
 
-#pragma - The following is service provide
+// - The following is service provide
     serviceType_accessoryInfo      = 0x3E,
     serviceType_camera             = 0x3F,
     serviceType_fan                = 0x40,
@@ -166,13 +166,13 @@ typedef enum {
     serviceType_battery            = 0x96,
     serviceType_carbonDioxideSensor= 0x97,
 
-#pragma - The following is for bluetooth characteristic
+// - The following is for bluetooth characteristic
     btCharType_pairSetup = 0x4C,
     btCharType_pairVerify = 0x4E,
     btCharType_pairingFeature = 0x4F,
     btCharType_pairings = 0x50,
     btCharType_serviceInstanceID = 0x51,
-#pragma - The following is for bluetooth service
+// - The following is for bluetooth service
     btServiceType_accessoryInformation = 0xFED3,
     btServiceType_camera            = 0xFEC9,
     btServiceType_fan               = 0xFECB,

--- a/src/HKBonjour.cpp
+++ b/src/HKBonjour.cpp
@@ -413,7 +413,6 @@ errorReturn:
 bool HKBonjour::run()
 {
    bool result = false;
-   uint8_t i;
    unsigned long now = millis();
    // now, should we re-announce our services again?
    if ((now - this->_lastAnnounceMillis) > 1000*MSNS_ANNOUNCE_TIME_SEC) {

--- a/src/HKBonjour.cpp
+++ b/src/HKBonjour.cpp
@@ -409,8 +409,6 @@ MDNSError_t HKBonjour::_sendMDNSMessage(uint32_t peerAddress, uint32_t xid, int 
 
    this->endPacket();
 
-errorReturn:
-
    hkLog.info("Bonjour advertised");
    return statusCode;
 }

--- a/src/HKBonjour.cpp
+++ b/src/HKBonjour.cpp
@@ -42,6 +42,11 @@
 #define  MDNS_MAX_SERVICES_PER_PACKET  6
 #define  MSNS_ANNOUNCE_TIME_SEC  1 //Send announce packet every 1 seconds
 
+// This is from Arduino Ethernet library types.h, and is included here to remove compiler warnings...
+#define	_ENDIAN_LITTLE_	0	/**<  This must be defined if system is little-endian alignment */
+#define	_ENDIAN_BIG_		1
+#define 	SYSTEM_ENDIAN		_ENDIAN_LITTLE_
+
 static uint8_t mdnsMulticastIPAddr[] = { 224, 0, 0, 251 };
 //static uint8_t mdnsHWAddr[] = { 0x01, 0x00, 0x5e, 0x00, 0x00, 0xfb };
 

--- a/src/HKConfig.cpp
+++ b/src/HKConfig.cpp
@@ -8,7 +8,7 @@
 
 
 int customRngFunc(byte* output, word32 sz) {
-  for(int i = 0; i<sz; i++) {
+  for(uint i = 0; i<sz; i++) {
     output[i] = rand();
   }
   return 0;

--- a/src/HKConfig.h
+++ b/src/HKConfig.h
@@ -23,4 +23,6 @@
 #define CUSTOM_RAND_GENERATE_BLOCK customRngFunc
 extern int customRngFunc(byte* output, word32 sz);
 
+#define WOLFSSL_IGNORE_FILE_WARN
+
 #endif

--- a/src/HKConnection.cpp
+++ b/src/HKConnection.cpp
@@ -137,7 +137,6 @@ void HKConnection::decryptData(uint8_t *payload, size_t *size)
             nonce[i++] = x % 256;
             x /= 256;
         }
-        size_t decrypted_len = *decrypted_size - decrypted_offset;
 
         int r = wc_ChaCha20Poly1305_Decrypt(
             (const byte *)writeKey,
@@ -378,7 +377,6 @@ bool HKConnection::handlePairVerify(const char *buffer)
 
         char salt[] = "Pair-Verify-Encrypt-Salt";
         char info[] = "Pair-Verify-Encrypt-Info";
-        size_t sessionKeySize = CHACHA20_POLY1305_AEAD_KEYSIZE;
         r = wc_HKDF(SHA512, (const byte *)sharedKey, sharedKeySize, (const byte *)salt, strlen(salt), (const byte *)info, strlen(info), sessionKeyData, CHACHA20_POLY1305_AEAD_KEYSIZE);
         if (r)
             hkLog.warn("wc_HKDF: r:%d", r);
@@ -387,7 +385,6 @@ bool HKConnection::handlePairVerify(const char *buffer)
         unsigned short msgLen = 0;
         data.rawData(&plainMsg, &msgLen);
 
-        size_t encryptMsgSize = 0;
         byte encryptMsg[msgLen + 16];
         r = wc_ChaCha20Poly1305_Encrypt(
             (const byte *)sessionKeyData,

--- a/src/HKConnection.cpp
+++ b/src/HKConnection.cpp
@@ -606,7 +606,7 @@ void HKConnection::handlePairSetup(const char *buffer)
         stateRecord.data[0] = State_M4_SRPVerifyRespond;
         const char *keyStr = 0;
         int keyLen = 0;
-        const char *proofStr;
+        char *proofStr = NULL;
         int proofLen = 0;
         keyStr = msg.data.dataPtrForIndex(3);
         keyLen = msg.data.lengthForIndex(3);

--- a/src/HKConnection.cpp
+++ b/src/HKConnection.cpp
@@ -262,7 +262,7 @@ bool HKConnection::handleConnection(bool maxConnectionsVictim)
 void HKConnection::announce(char *desc)
 {
     memset(SHARED_RESPONSE_BUFFER, 0, SHARED_RESPONSE_BUFFER_LEN);
-    int len = snprintf((char*)SHARED_RESPONSE_BUFFER, SHARED_RESPONSE_BUFFER_LEN, "EVENT/1.0 200 OK\r\nContent-Type: application/hap+json\r\nContent-Length: %lu\r\n\r\n%s", strlen(desc), desc);
+    int len = snprintf((char*)SHARED_RESPONSE_BUFFER, SHARED_RESPONSE_BUFFER_LEN, "EVENT/1.0 200 OK\r\nContent-Type: application/hap+json\r\nContent-Length: %u\r\n\r\n%s", strlen(desc), desc);
     hkLog.info("Announce: %s, data: %s", clientID(), SHARED_RESPONSE_BUFFER);
     writeData((byte *)SHARED_RESPONSE_BUFFER, len);
 }

--- a/src/HKConnection.cpp
+++ b/src/HKConnection.cpp
@@ -29,7 +29,7 @@ HKConnection::HKConnection(HKServer *s, TCPClient c)
 
 HKConnection::~HKConnection()
 {
-    for (int i = 0; i < notifiableCharacteristics.size(); i++)
+    for (uint i = 0; i < notifiableCharacteristics.size(); i++)
     {
         notifiableCharacteristics.at(i)->removeNotifiedConnection(this);
     }
@@ -50,7 +50,7 @@ void HKConnection::writeEncryptedData(uint8_t *payload, size_t size)
     delay(100);
     memset(SHARED_TEMP_CRYPTO_BUFFER, 0, SHARED_TEMP_CRYPTO_BUFFER_LEN);
 
-    int payload_offset = 0;
+    uint payload_offset = 0;
     int part = 0;
     while (payload_offset < size)
     {
@@ -119,7 +119,7 @@ void HKConnection::decryptData(uint8_t *payload, size_t *size)
     byte nonce[12];
     memset(nonce, 0, sizeof(nonce));
 
-    int payload_offset = 0;
+    uint payload_offset = 0;
     int decrypted_offset = 0;
     while (payload_offset < payload_size)
     {
@@ -270,7 +270,7 @@ void HKConnection::announce(char *desc)
 
 void HKConnection::processPostedCharacteristics()
 {
-    for (int i = 0; i < postedCharacteristics.size(); i++)
+    for (uint i = 0; i < postedCharacteristics.size(); i++)
     {
         characteristics *c = postedCharacteristics.at(i);
         int len = snprintf(NULL, 0, "{\"characteristics\":[{\"aid\": %d, \"iid\": %d, \"value\": %s}]}", c->accessory->aid, c->iid, c->value(NULL).c_str());
@@ -848,7 +848,7 @@ void HKConnection::handleAccessoryRequest(const char *buffer, size_t size)
 
 void HKConnection::postCharacteristicsValue(characteristics *c)
 {
-    for (int i = 0; i < postedCharacteristics.size(); i++)
+    for (uint i = 0; i < postedCharacteristics.size(); i++)
     {
         characteristics *item = postedCharacteristics.at(i);
         if (c == item)

--- a/src/HKNetworkMessage.cpp
+++ b/src/HKNetworkMessage.cpp
@@ -51,7 +51,7 @@ void HKNetworkMessage::getBinaryPtr(char **buffer, int *contentLength) {
     const char *_data; unsigned short dataSize;
     data.rawData(&_data, &dataSize);
     (*buffer) = new char[1024];
-    (*contentLength) = snprintf((*buffer), 1024, "%s /%s HTTP/1.1\r\nContent-Length: %hu\r\n\Content-Type: %s\r\n\r\n", method, directory, dataSize, type);
+    (*contentLength) = snprintf((*buffer), 1024, "%s /%s HTTP/1.1\r\nContent-Length: %hu\r\nContent-Type: %s\r\n\r\n", method, directory, dataSize, type);
     for (int i = 0; i < dataSize; i++) {
         (*buffer)[*contentLength+i] = _data[i];
     }

--- a/src/HKNetworkMessageData.cpp
+++ b/src/HKNetworkMessageData.cpp
@@ -56,7 +56,7 @@ void HKNetworkMessageData::rawData(const char **dataPtr, unsigned short *len) {
     string buffer = "";
     for (int i = 0; i < 10; i++) {
         if (records[i].activate) {
-            for (int j = 0; j != records[i].length;) {
+            for (uint j = 0; j != records[i].length;) {
                 unsigned char len = records[i].length-j>255?255:records[i].length-j;
                 string temp(&records[i].data[j], len);
                 temp = (char)records[i].index+((char)len+temp);

--- a/src/HKServer.cpp
+++ b/src/HKServer.cpp
@@ -44,7 +44,7 @@ void HKServer::start () {
 }
 
 void HKServer::stop () {
-    for(int i = 0; i < clients.size(); i++) {
+    for(uint i = 0; i < clients.size(); i++) {
       HKConnection *conn = clients.at(i);
       conn->close();
       delete conn;

--- a/src/HKServer.cpp
+++ b/src/HKServer.cpp
@@ -73,7 +73,7 @@ void HKServer::setPaired(bool p) {
     sprintf(deviceTypeStr, "%d",deviceType);
 
     char recordTxt[160] = {0};
-    int len = sprintf(recordTxt, "%csf=%d%cid=%s%cpv=1.0%cc#=%s%cs#=1%cff=0%cmd=%s%cci=%s",4, p ? 0 : 1,(char)deviceIdentity.length()+3,deviceIdentity.c_str(),6,3+configNumberLen,configNumberStr,4,4,(char)hapName.length() + 3,hapName.c_str(),3 + strlen(deviceTypeStr),deviceTypeStr);
+    sprintf(recordTxt, "%csf=%d%cid=%s%cpv=1.0%cc#=%s%cs#=1%cff=0%cmd=%s%cci=%s",4, p ? 0 : 1,(char)deviceIdentity.length()+3,deviceIdentity.c_str(),6,3+configNumberLen,configNumberStr,4,4,(char)hapName.length() + 3,hapName.c_str(),3 + strlen(deviceTypeStr),deviceTypeStr);
 
     char bonjourName[128] = {0};
 

--- a/src/HKStringBuffer.h
+++ b/src/HKStringBuffer.h
@@ -80,6 +80,12 @@ public:
         this->append(rhs);
         return *this; // return the result by reference
     }
+
+    HKStringBuffer& operator+=(const char* rhs) 
+    {
+        this->append(rhs);
+        return *this;
+    }
 };
 
 #endif /* HKStringBuffer_hpp */

--- a/src/crypto/misc.cpp
+++ b/src/crypto/misc.cpp
@@ -46,8 +46,9 @@
 
 /* Check for if compiling misc.c when not needed. */
 #if !defined(WOLFSSL_MISC_INCLUDED) && !defined(NO_INLINE)
-#warning misc.c does not need to be compiled when using inline (NO_INLINE not defined)
-
+    #ifndef WOLFSSL_IGNORE_FILE_WARN
+        #warning misc.c does not need to be compiled when using inline (NO_INLINE not defined)
+    #endif
 #else
 
 

--- a/src/crypto/random.h
+++ b/src/crypto/random.h
@@ -154,6 +154,9 @@ extern "C" {
     /* NO_OLD_RNGNAME removes RNG struct name to prevent possible type conflicts,
      * can't be used with CTaoCrypt FIPS */
 #if !defined(NO_OLD_RNGNAME) && !defined(HAVE_FIPS)
+#ifdef RNG
+#undef RNG
+#endif
 #define RNG WC_RNG
 #endif
     


### PR DESCRIPTION
Worked through library to remove all code generating compiler warnings (building with Particle Workbench, macOS, tested with deviceOS 1.5.1).