### PR TITLE
Add flag to toggle logging using Particle cloud events

### DIFF
--- a/src/HKConfig.h
+++ b/src/HKConfig.h
@@ -25,4 +25,6 @@ extern int customRngFunc(byte* output, word32 sz);
 
 #define WOLFSSL_IGNORE_FILE_WARN
 
+#define DEBUG_PARTICLE_EVENTS
+
 #endif

--- a/src/HKConnection.cpp
+++ b/src/HKConnection.cpp
@@ -214,7 +214,9 @@ bool HKConnection::handleConnection(bool maxConnectionsVictim)
         if (!strcmp(msg.directory, "pair-setup"))
         {
             hkLog.info("Handling Pair Setup...");
+#ifdef DEBUG_PARTICLE_EVENTS
             Particle.publish("homekit/pair-setup", clientID(), PRIVATE);
+#endif
             handlePairSetup((const char *)SHARED_REQUEST_BUFFER);
         }
         else if (!strcmp(msg.directory, "pair-verify"))
@@ -223,14 +225,18 @@ bool HKConnection::handleConnection(bool maxConnectionsVictim)
             if (!maxConnectionsVictim)
             {
               hkLog.info("Handling Pair Verify...");
+#ifdef DEBUG_PARTICLE_EVENTS
               Particle.publish("homekit/pair-verify", clientID(), PRIVATE);
+#endif
               if (handlePairVerify((const char *)SHARED_REQUEST_BUFFER))
               {
                   isEncrypted = true;
                   server->setPaired(true);
               }
             } else {
+#ifdef DEBUG_PARTICLE_EVENTS
                   Particle.publish("homekit/connection-limit", clientID(), PRIVATE);
+#endif
                   //max connections has been reached.
                   memset(SHARED_RESPONSE_BUFFER, 0, SHARED_RESPONSE_BUFFER_LEN);
                   int len = snprintf((char *)SHARED_RESPONSE_BUFFER, SHARED_RESPONSE_BUFFER_LEN, "HTTP/1.1 503 Service Unavailable\r\n\r\n");
@@ -247,7 +253,9 @@ bool HKConnection::handleConnection(bool maxConnectionsVictim)
         {
           //connection is secured
           hkLog.info("Handling message request: %s", msg.directory);
+#ifdef DEBUG_PARTICLE_EVENTS
           Particle.publish("homekit/accessory", clientID(), PRIVATE);
+#endif
           handleAccessoryRequest((const char *)SHARED_REQUEST_BUFFER, len);
         }
 

--- a/src/HKServer.cpp
+++ b/src/HKServer.cpp
@@ -108,7 +108,9 @@ bool HKServer::handle() {
             i--;
         }
         clients.insert(clients.end(),c);
+#ifdef DEBUG_PARTICLE_EVENTS
         Particle.publish("homekit/accept", c->clientID(), PRIVATE);
+#endif
         result = true;
     }
 
@@ -120,7 +122,9 @@ bool HKServer::handle() {
 
         if(!conn->isConnected()) {
             hkLog.info("Client removed.");
+#ifdef DEBUG_PARTICLE_EVENTS
             Particle.publish("homekit/close", conn->clientID(), PRIVATE);
+#endif
             conn->close();
             clients.erase(clients.begin() + i);
             delete conn;


### PR DESCRIPTION
`DEBUG_PARTICLE_EVENTS` can now be #defined in `src/HKConfig.h` to enable or disable logging Homekit traffic to the Particle cloud.

Related post: https://community.particle.io/t/homekit-connect-your-photon-to-homekit-without-homebridge/47332/86