### PR TITLE
Make debugging events optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Example video of pairing and handling.
 //So allow 8 connections, every 9th will be closed send HTTP 503 and closed.
 //It seems that even 2 connections are working just fine, if you need to use sockets for something else.
 #define MAX_CONNECTIONS 8
+// Enable Particle event publishing when various HomeKit events take place
+#define DEBUG_PARTICLE_EVENTS
 
 ```
 

--- a/src/HKConfig.h
+++ b/src/HKConfig.h
@@ -25,6 +25,4 @@ extern int customRngFunc(byte* output, word32 sz);
 
 #define WOLFSSL_IGNORE_FILE_WARN
 
-#define DEBUG_PARTICLE_EVENTS
-
 #endif


### PR DESCRIPTION
Particle now limits free tier usage to 100k events per month, which is easy to exceed with 2 devices using Particle-HAP.

All `Particle.publish` calls are already wrapped in `#ifdef DEBUG_PARTICLE_EVENTS`, I think it makes sense to remove this definition from the library, and add it to user's code if they want to enable these events.